### PR TITLE
Fix bug where hierarchy elements could be cleared

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = pathlib.Path(__file__).parent.resolve()
 
 long_description = (here / "README.md").read_text(encoding="utf-8")
 
-VERSION = "0.9.2"
+VERSION = "0.9.3"
 
 setup(
     name="tm1cm",


### PR DESCRIPTION
If a tm1cm.yaml config was set to exclude elements for a hierarchy, and then the elementattributes of that hierarchy changed, tm1cm would clear all elements from the hierarchy.